### PR TITLE
Faker gem 移出 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'mini_magick', '~> 4.5', '>= 4.5.1'
 gem 'rails-i18n'
 gem 'aasm', '~> 5.0', '>= 5.0.6'
 gem 'friendly_id', '~> 5.3'
+gem 'faker', '~> 2.4'
 
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
@@ -54,7 +55,6 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'hirb-unicode', '~> 0.0.5'
-  gem 'faker', '~> 2.4'
 end
 
 group :development do


### PR DESCRIPTION
將 gem faker 移動到外層，讓 production 環境也能使用，解決推送 heroku 時 compile 失敗的問題

惟凡的 remote
https://github.com/Fan1985/food_project.git 